### PR TITLE
Bump json-diff to 0.4.1 - fix compile warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ description = "A flexible rule-based file and folder comparison tool and crate i
 repository = "https://github.com/VolumeGraphics/havocompare"
 homepage = "https://github.com/VolumeGraphics/havocompare"
 documentation = "https://docs.rs/havocompare"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license = "MIT"
 authors = ["Volume Graphics GmbH"]
 exclude = ["tests/pdf", "tests/integ", "tests/html", "target", "tests/csv", ".github", "test_report"]
-keywords = ["diff" ,"compare", "csv", "image", "difference"]
+keywords = ["diff", "compare", "csv", "image", "difference"]
 categories = ["filesystem"]
 
 [[bin]]
@@ -18,7 +18,7 @@ path = "src/print_args.rs"
 
 
 [dependencies]
-clap = {version= "4.4", features=["derive"]}
+clap = { version = "4.4", features = ["derive"] }
 chrono = "0.4"
 serde = "1.0"
 serde_yaml = "0.9"
@@ -32,7 +32,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 serde_json = "1.0"
 glob = "0.3"
-test-log = {version="0.2", features=["trace"]}
+test-log = { version = "0.2", features = ["trace"] }
 strsim = "0.11"
 itertools = "0.12"
 tera = "1.19"
@@ -47,10 +47,10 @@ tempfile = "3.8"
 fs_extra = "1.3"
 opener = "0.6"
 anyhow = "1.0"
-json_diff_ng = {version = "0.4"}
+json_diff_ng = { version = "0.4" }
 
 
 [dev-dependencies]
 env_logger = "0.11"
-tracing = {version = "0.1", default-features = false}
-tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,6 @@ pub fn validate_config(config_file: impl AsRef<Path>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::image::ImageCompareConfig;
     #[test]
     fn folder_not_found_is_false() {
         let rule = Rule {


### PR DESCRIPTION
- fixes a bug in deeply nested array sorting. Thanks @tsvetso-spread for finding and fixing!